### PR TITLE
Issues 27 and 28

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="hg4idea" />
+    <mapping directory="" vcs="Git" />
   </component>
 </project>
 


### PR DESCRIPTION
It may look a bit weird but it works...

1. Method getNavigationElement() is used to get the source file by the class file, so external libraries are imported correctly
2. Comments and javadocs should be just deleted, because the way to determine the start of the class doesn't work if the javadocs contain a substring "class" or "interface"