### PR TITLE
fix url parsing for codeforces problemset

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -18,7 +18,7 @@ chrome.tabs.onUpdated.addListener(checkForValidUrl);
 function parseTask(tab) {
     if (/^https:\/\/.*contest2?[.]yandex[.](ru|com)\/.*contest\/\d*\/problems.*$/.test(tab.url)) {
         chrome.tabs.sendMessage(tab.id, 'yandex');
-    } else if (/^^http:\/\/codeforces[.](ru|com)\/(contest|problemset|gym)\/(\d*\/problem|problem\/\d*)\/.+$/.test(tab.url)) {
+    } else if (/^http:\/\/codeforces[.](ru|com)\/(contest|problemset|gym)\/(\d*\/problem|problem\/\d*)\/.+$/.test(tab.url)) {
         chrome.tabs.sendMessage(tab.id, 'codeforces');
     } else if (/^https:\/\/(www[.])?hackerrank[.]com\/(contests\/.+\/)?challenges\/[^/]+$/.test(tab.url)) {
         chrome.tabs.sendMessage(tab.id, 'hackerrank');

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,6 +1,6 @@
 function checkForValidUrl(tabId, changeInfo, tab) {
     if (/^https:\/\/.*contest2?[.]yandex[.](ru|com)\/.*contest\/\d*\/problems.*$/.test(tab.url) ||
-        /^http:\/\/codeforces[.](ru|com)\/(contest|problemset|gym)\/\d*\/problem\/.+$/.test(tab.url) ||
+        /^http:\/\/codeforces[.](ru|com)\/(contest|problemset|gym)\/(\d*\/problem|problem\/\d*)\/.+$/.test(tab.url) ||
         /^https:\/\/(www[.])?hackerrank[.]com\/(contests\/.+\/)?challenges\/[^/]+$/.test(tab.url) ||
         /^https:\/\/www[.]facebook[.]com\/hackercup\/problems[.]php.+$/.test(tab.url) ||
         /^http:\/\/(www[.])?usaco[.]org\/index[.]php[?]page[=]viewproblem.*$/.test(tab.url) ||
@@ -18,7 +18,7 @@ chrome.tabs.onUpdated.addListener(checkForValidUrl);
 function parseTask(tab) {
     if (/^https:\/\/.*contest2?[.]yandex[.](ru|com)\/.*contest\/\d*\/problems.*$/.test(tab.url)) {
         chrome.tabs.sendMessage(tab.id, 'yandex');
-    } else if (/^http:\/\/codeforces[.](ru|com)\/(contest|problemset|gym)\/\d*\/problem\/.+$/.test(tab.url)) {
+    } else if (/^^http:\/\/codeforces[.](ru|com)\/(contest|problemset|gym)\/(\d*\/problem|problem\/\d*)\/.+$/.test(tab.url)) {
         chrome.tabs.sendMessage(tab.id, 'codeforces');
     } else if (/^https:\/\/(www[.])?hackerrank[.]com\/(contests\/.+\/)?challenges\/[^/]+$/.test(tab.url)) {
         chrome.tabs.sendMessage(tab.id, 'hackerrank');


### PR DESCRIPTION
In problemset, the number comes after problem (i.e. http://codeforces.com/problemset/problem/529/B), so original regex was failing for this case.