### PR TITLE
Fix issue 'unable to save changed tests'

### DIFF
--- a/src/net/egork/chelper/ProjectData.java
+++ b/src/net/egork/chelper/ProjectData.java
@@ -88,9 +88,7 @@ public class ProjectData {
                 if (root == null)
                     return;
                 try {
-                    VirtualFile config = root.findChild("chelper.properties");
-                    if (config == null)
-                        config = root.createChildData(null, "chelper.properties");
+                    VirtualFile config = root.findOrCreateChildData(null, "chelper.properties");
                     Properties properties = new Properties();
                     properties.setProperty("inputClass", inputClass);
                     properties.setProperty("outputClass", outputClass);

--- a/src/net/egork/chelper/util/CodeGenerationUtilities.java
+++ b/src/net/egork/chelper/util/CodeGenerationUtilities.java
@@ -486,7 +486,7 @@ public class CodeGenerationUtilities {
             public void run() {
                 String taskFilePath;
                 try {
-                    VirtualFile taskFile = directory.createChildData(null, ArchiveAction.canonize(finalTask.name) + ".task");
+                    VirtualFile taskFile = directory.findOrCreateChildData(null, ArchiveAction.canonize(finalTask.name) + ".task");
                     OutputStream outputStream = taskFile.getOutputStream(null);
                     finalTask.saveTask(new OutputWriter(outputStream));
                     outputStream.close();
@@ -562,7 +562,7 @@ public class CodeGenerationUtilities {
             public void run() {
                 String taskFilePath;
                 try {
-                    VirtualFile taskFile = directory.createChildData(null, finalTask.name + ".tctask");
+                    VirtualFile taskFile = directory.findOrCreateChildData(null, finalTask.name + ".tctask");
                     OutputStream outputStream = taskFile.getOutputStream(null);
                     finalTask.saveTask(new OutputWriter(outputStream));
                     outputStream.close();

--- a/src/net/egork/chelper/util/FileUtilities.java
+++ b/src/net/egork/chelper/util/FileUtilities.java
@@ -77,10 +77,7 @@ public class FileUtilities {
 				}
 				OutputStream stream = null;
 				try {
-					VirtualFile file = location.createChildData(null, fileName);
-					if (file == null) {
-						return;
-					}
+					VirtualFile file = location.findOrCreateChildData(null, fileName);
 					stream = file.getOutputStream(null);
 					stream.write(fileContent.getBytes(Charset.forName("UTF-8")));
 				} catch (IOException ignored) {
@@ -231,7 +228,7 @@ public class FileUtilities {
 				}
 				OutputStream stream = null;
 				try {
-					VirtualFile file = location.createChildData(null, fileName);
+					VirtualFile file = location.findOrCreateChildData(null, fileName);
 					if (file == null) {
 						return;
 					}
@@ -262,10 +259,7 @@ public class FileUtilities {
 				}
 				OutputStream stream = null;
 				try {
-					VirtualFile file = location.createChildData(null, fileName);
-					if (file == null) {
-						return;
-					}
+					VirtualFile file = location.findOrCreateChildData(null, fileName);
 					stream = file.getOutputStream(null);
 					configuration.saveTask(new OutputWriter(stream));
 				} catch (IOException ignored) {


### PR DESCRIPTION
Issue: unable to save changed test

Steps:
1. Add task, add tests to task (or parse any contest)
2. Go to the settings
3. Change test (disable, add new test, or change input/output data)
4. Click save
5. Open TASK**.task file

Act:
5. File unchanged

Exp:
5. Test data is changed

Fix:
there was exception while writing TASK**.task to the disk 'This file already exists'.
There should be findOrCreateFile instead of createFile. 
Fixed now.
