### PR TITLE
Fix IndexNotReadyException issue

### DIFF
--- a/src/net/egork/chelper/AutoSwitcher.java
+++ b/src/net/egork/chelper/AutoSwitcher.java
@@ -80,7 +80,12 @@ public class AutoSwitcher implements ProjectComponent {
 		FileEditorManager.getInstance(project).addFileEditorManagerListener(new FileEditorManagerAdapter() {
 			@Override
 			public void fileOpened(FileEditorManager source, VirtualFile file) {
-				selectTask(file);
+				DumbService.getInstance(project).smartInvokeLater(new Runnable() {
+					@Override
+					public void run() {
+						selectTask(file);
+					}
+				});
 			}
 
 			private void selectTask(VirtualFile file) {
@@ -112,7 +117,12 @@ public class AutoSwitcher implements ProjectComponent {
 
 			@Override
 			public void selectionChanged(FileEditorManagerEvent event) {
-				selectTask(event.getNewFile());
+				DumbService.getInstance(project).smartInvokeLater(new Runnable() {
+					@Override
+					public void run() {
+						selectTask(event.getNewFile());
+					}
+				});
 			}
 		});
 	}

--- a/src/net/egork/chelper/AutoSwitcher.java
+++ b/src/net/egork/chelper/AutoSwitcher.java
@@ -80,7 +80,7 @@ public class AutoSwitcher implements ProjectComponent {
 		});
 		FileEditorManager.getInstance(project).addFileEditorManagerListener(new FileEditorManagerAdapter() {
 			@Override
-			public void fileOpened(FileEditorManager source, final VirtualFile file) {
+			public void fileOpened(FileEditorManager source, VirtualFile file) {
 				selectTask(file);
 			}
 
@@ -120,7 +120,7 @@ public class AutoSwitcher implements ProjectComponent {
 			}
 
 			@Override
-			public void selectionChanged(final FileEditorManagerEvent event) {
+			public void selectionChanged(FileEditorManagerEvent event) {
 				selectTask(event.getNewFile());
 			}
 		});


### PR DESCRIPTION
According to documentation of IndexNotReadyException:

Thrown on accessing indices in dumb mode. Possible fixes:
1. if com.intellij.openapi.actionSystem.AnAction.actionPerformed(com.intellij.openapi.actionSystem.AnActionEvent) is in stack trace, consider making the action not implement DumbAware.
2. if this access is performed from some invokeLater activity, consider replacing it with DumbService.smartInvokeLater(java.lang.Runnable)
3. otherwise, add DumbService.isDumb() checks where necessary

It seems that 2nd solution is more reasonable