### PR TITLE
Make Codeforces parser work from Chrome again

### DIFF
--- a/src/net/egork/chelper/parser/CodeforcesParser.java
+++ b/src/net/egork/chelper/parser/CodeforcesParser.java
@@ -164,10 +164,10 @@ public class CodeforcesParser implements Parser {
 			while (true) {
 				try {
 					parser.advance(false, "<div class=\"input\">", "<DIV class=\"input\">");
-					parser.advance(true, "<pre>", "<PRE>");
+					skipPreMaybeWithId(parser);
 					String testInput = parser.advance(false, "</pre>", "</PRE>").replace("<br />", "\n").replace("<br>", "\n").replace("<BR/>", "\n");
 					parser.advance(false, "<div class=\"output\">", "<DIV class=\"output\">");
-					parser.advance(true, "<pre>", "<PRE>");
+					skipPreMaybeWithId(parser);
 					String testOutput = parser.advance(false, "</pre>", "</PRE>").replace("<br />", "\n").replace("<br>", "\n").replace("<BR/>", "\n");
 					tests.add(new Test(StringEscapeUtils.unescapeHtml(testInput),
 						StringEscapeUtils.unescapeHtml(testOutput), tests.size()));
@@ -183,5 +183,14 @@ public class CodeforcesParser implements Parser {
 		} catch (ParseException e) {
 			return Collections.emptyList();
 		}
+	}
+
+	private void skipPreMaybeWithId(StringParser parser) throws ParseException {
+		parser.advance(true, "<pre", "<PRE");
+		if (parser.startsWith(" id=\"") || parser.startsWith(" ID=\"")) {
+			parser.advance(true, "\"");
+			parser.advance(true, "\"");
+		}
+		parser.advance(true, ">");
 	}
 }


### PR DESCRIPTION
… by adapting to the new Javascript-generated ids for inputs.

Ideally we'd get the "before Javascript" HTML code from the extension to the plugin, to avoid supporting two different formats, but it seems that there isn't a way to get the original HTML in Chrome short of just loading it again, which would be bad in situations where Codeforces is unstable.