### PR TITLE
Regex Support patch

### DIFF
--- a/src/net/egork/chelper/parser/CodeforcesParser.java
+++ b/src/net/egork/chelper/parser/CodeforcesParser.java
@@ -164,10 +164,10 @@ public class CodeforcesParser implements Parser {
 			while (true) {
 				try {
 					parser.advance(false, "<div class=\"input\">", "<DIV class=\"input\">");
-					skipPreMaybeWithId(parser);
+					parser.advanceRegex(true, "<pre [^>]+>", "<PRE [^>]+>");
 					String testInput = parser.advance(false, "</pre>", "</PRE>").replace("<br />", "\n").replace("<br>", "\n").replace("<BR/>", "\n");
 					parser.advance(false, "<div class=\"output\">", "<DIV class=\"output\">");
-					skipPreMaybeWithId(parser);
+					parser.advanceRegex(true, "<pre [^>]+>", "<PRE [^>]+>");
 					String testOutput = parser.advance(false, "</pre>", "</PRE>").replace("<br />", "\n").replace("<br>", "\n").replace("<BR/>", "\n");
 					tests.add(new Test(StringEscapeUtils.unescapeHtml(testInput),
 						StringEscapeUtils.unescapeHtml(testOutput), tests.size()));
@@ -185,12 +185,4 @@ public class CodeforcesParser implements Parser {
 		}
 	}
 
-	private void skipPreMaybeWithId(StringParser parser) throws ParseException {
-		parser.advance(true, "<pre", "<PRE");
-		if (parser.startsWith(" id=\"") || parser.startsWith(" ID=\"")) {
-			parser.advance(true, "\"");
-			parser.advance(true, "\"");
-		}
-		parser.advance(true, ">");
-	}
 }

--- a/src/net/egork/chelper/parser/StringParser.java
+++ b/src/net/egork/chelper/parser/StringParser.java
@@ -1,6 +1,8 @@
 package net.egork.chelper.parser;
 
 import java.text.ParseException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author Egor Kulikov (kulikov@devexperts.com)
@@ -43,10 +45,45 @@ public class StringParser implements CharSequence {
 			underlying = underlying.substring(position);
 		return result;
 	}
+	
+	public String advanceRegex(boolean toEnd, String...samples) throws ParseException {
+		int position = -1;
+		int targetSampleLength = 0;
+		for (String sample : samples) {
+			int candidate = -1;
+			Pattern ptr=Pattern.compile(sample);
+			Matcher mtc=ptr.matcher(underlying);
+			int last_index=candidate;
+			if(mtc.find()) {
+				candidate=mtc.start();
+				last_index=mtc.end();
+			}
+			if (position == -1 || candidate != -1 && candidate < position) {
+				position = candidate;
+				targetSampleLength = last_index-candidate;
+			}
+		}
+		if (position == -1)
+			throw new ParseException(underlying, -1);
+		String result = underlying.substring(0, position);
+		if (toEnd)
+			underlying = underlying.substring(position + targetSampleLength);
+		else
+			underlying = underlying.substring(position);
+		return result;
+	}
 
 	public String advanceIfPossible(boolean toEnd, String...samples) {
 		try {
 			return advance(toEnd, samples);
+		} catch (ParseException e) {
+			return null;
+		}
+	}
+	
+	public String advanceRegexIfPossible(boolean toEnd, String...samples) {
+		try {
+			return advanceRegex(toEnd, samples);
 		} catch (ParseException e) {
 			return null;
 		}


### PR DESCRIPTION
Recently after some changes on codeforces, chelper stopped working (issue #52) due to extra added attributes. Which lead to changes in [CodeforcesParser.java](https://github.com/EgorKulikov/idea-chelper/blob/master/src/net/egork/chelper/parser/CodeforcesParser.java). commit #53 by @petrmitrichev  fixed that issue but that solution is very specific for this problem. In future also due to some external changes will break the code and adding separate methods for fixing each issue is not feasible.

**Use of Regular Expressions for matching can make code more flexible against future external changes. It will be very easy to fix the issue as regex (Regular Expression) is more general purpose than custom function. The regex will also facilitate complex pattern matching and dynamic pattern matching, in which contents of the pattern is not fixed.**

In this branch, I have added advanceRegex() method to [StringParser.java](https://github.com/EgorKulikov/idea-chelper/blob/master/src/net/egork/chelper/parser/StringParser.java) , which adds support to use the regular expression as samples. And to fix issue #52 and to demonstrate the use of Regex I have also modified [CodeforcesParser.java](https://github.com/EgorKulikov/idea-chelper/blob/master/src/net/egork/chelper/parser/CodeforcesParser.java), From the code, it is clear that matching issues can be fixed easily and you don't need to add extra methods inside each parser.