### PR TITLE
Ensure libraries on project open

### DIFF
--- a/src/net/egork/chelper/util/Utilities.java
+++ b/src/net/egork/chelper/util/Utilities.java
@@ -94,9 +94,6 @@ public class Utilities {
 
     private static void ensureLibrary(final Project project) {
         final ProjectData data = Utilities.getData(project);
-        if (data.libraryVersion == ProjectData.CURRENT_LIBRARY_VERSION) {
-            return;
-        }
         fixLibrary(project);
         data.completeMigration(project);
     }


### PR DESCRIPTION
Fix #68 .

Hi @EgorKulikov , I'm not sure if it's ok to wait some extra milliseconds for libraries to be added or not. But I think this might fix problems like new module added, or new project imported, etc.