### PR TITLE
Fix Codeforces parser to accept <pre> tag without attributes in tests

### DIFF
--- a/src/net/egork/chelper/parser/CodeforcesParser.java
+++ b/src/net/egork/chelper/parser/CodeforcesParser.java
@@ -173,10 +173,10 @@ public class CodeforcesParser implements Parser {
             while (true) {
                 try {
                     parser.advance(false, "<div class=\"input\">", "<DIV class=\"input\">");
-                    parser.advanceRegex(true, "<pre [^>]+>", "<PRE [^>]+>");
+                    parser.advanceRegex(true, "<pre( [^>]+|)>", "<PRE( [^>]+|)>");
                     String testInput = parser.advance(false, "</pre>", "</PRE>").replace("<br />", "\n").replace("<br>", "\n").replace("<BR/>", "\n");
                     parser.advance(false, "<div class=\"output\">", "<DIV class=\"output\">");
-                    parser.advanceRegex(true, "<pre [^>]+>", "<PRE [^>]+>");
+                    parser.advanceRegex(true, "<pre( [^>]+|)>", "<PRE( [^>]+|)>");
                     String testOutput = parser.advance(false, "</pre>", "</PRE>").replace("<br />", "\n").replace("<br>", "\n").replace("<BR/>", "\n");
                     tests.add(new Test(StringEscapeUtils.unescapeHtml(testInput),
                             StringEscapeUtils.unescapeHtml(testOutput), tests.size()));


### PR DESCRIPTION
Currently Codeforces samples have no attributes in `<pre>` tag
E.g. https://codeforces.com/contest/1057/problem/A 
`<div class="input"><div class="title">Input</div><pre>8<br />1 1 2 2 3 2 5<br /></pre></div><div class="output"><div class="title">Output</div><pre>1 2 5 8 </pre></div><div class="input">`
